### PR TITLE
fixed how custom scorers are integrated into the data_modelling.py fu…

### DIFF
--- a/ai_toolbox/setup.py
+++ b/ai_toolbox/setup.py
@@ -34,7 +34,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.15.4',  # Required
+    version='0.15.5',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/ai_toolbox/src/ai_toolbox/data_preparation.py
+++ b/ai_toolbox/src/ai_toolbox/data_preparation.py
@@ -141,16 +141,3 @@ if __name__ == '__main__':
     This module is not supposed to run as a stand-alone module.
     This part below is only for testing purposes. 
     """
-
-    from os.path import join
-
-    dataset_dir = "/home/rick/Coding/Notebooks/datasets"
-    filename = join(dataset_dir, "tem_yearly_temp.csv")
-    df = pd.read_csv(
-        filename,
-        sep=',',
-        parse_dates=True,
-        infer_datetime_format=True,
-        index_col=0)
-    df.index.name = "timestamp"
-    print(detect_time_step(df))

--- a/ai_toolbox/src/ai_toolbox/data_transformation.py
+++ b/ai_toolbox/src/ai_toolbox/data_transformation.py
@@ -8,12 +8,13 @@ from itertools import chain
 import holidays
 import pandas as pd
 import pytz
-from ai_toolbox.data_preparation import detect_time_step
 from numpy import pi, sin, cos
 from pandas.tseries.frequencies import to_offset
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import FunctionTransformer
+
+from ai_toolbox.data_preparation import detect_time_step
 
 
 def yearly_profile_detection(data, exclude_days=None):

--- a/ai_toolbox/src/ai_toolbox/perfomance_metrics.py
+++ b/ai_toolbox/src/ai_toolbox/perfomance_metrics.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from sklearn.metrics import make_scorer, SCORERS
+from sklearn.metrics import make_scorer
 from sklearn.utils.validation import check_consistent_length
 
 
@@ -119,11 +119,11 @@ cv_rmse_scorer = make_scorer(
     multioutput='uniform_average',
     number_of_parameters=1)
 
-SCORERS.update({
+custom_scorers = {
     'mean_bias_error': mean_bias_error_scorer,
     'normalized_mean_bias_error': normalized_mean_bias_error_scorer,
     'cv_rmse': cv_rmse_scorer
-})
+}
 
 if __name__ == '__main__':
     """
@@ -131,7 +131,3 @@ if __name__ == '__main__':
     This part below is only for testing purposes. 
     """
 
-    y_true = np.array([-2, -1, 0, 1, 2])
-    y_pred = np.array([-3, -2, 1, 3, 2])
-
-    print(mean_bias_error(y_true=y_true, y_pred=y_pred, normalized=True))


### PR DESCRIPTION
Custom scorers defined in performance_metrics.py are meant to extend the predefined scikit-learn scorers and support all the BC needs. In the ai-toolbox functions one would use the predefined and custom scorers the same way, i.e. specifying their string name.