### PR TITLE
Fixed deprecation warning when getting calendar components as attribute of DatetimeIndex

### DIFF
--- a/ai_toolbox/setup.py
+++ b/ai_toolbox/setup.py
@@ -34,7 +34,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.15.5',  # Required
+    version='0.15.6',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Fixed deprecation warning when getting calendar components as attribute of DatetimeIndex for 'week' and 'weekofyear'